### PR TITLE
evtypebits work for both arms: using DR. and DL. Added small bug fix …

### DIFF
--- a/replay/DB/db_DL.dat
+++ b/replay/DB/db_DL.dat
@@ -2,134 +2,46 @@
 # Example decoder data definition file
 # Taken from December 2012 online replay database
 # See THaDecData.C for documentation.
-
 DL.word =
-# event number
-evtroc3           3    fabc0008   4
-evtroc4           4    fabc0008   4
-evtroc5           5    fabc0008   4
-evttsroc          11   cafe0000   1
-# evtroc31         31    fabc0008   4 // didn't check
-#
-# event type
-evtyperoc3           3    fabc0008   5
-evtyperoc4           4    fabc0008   5
-evtyperoc5           5    fabc0008   5
-evtypetsroc          11   cafe0000   -8
-# evtyperoc31         31    fabc0008   5 // didn't check
-#
-# event count
-evtcntroc3           3    fabc0008   6
-evtcntroc4           4    fabc0008   6
-evtcntroc5           5    fabc0008   6
-# evtcntroc31         31    fabc0008   6 // didn't check
-#
-# vxclock
-vxroc3           3    fabc0008   7
-vxroc4           4    fabc0008   7
-vxroc5           5    fabc0008   7
-vxtsroc          11   cafe0000   -4
-# vxroc31         31    fabc0008   7 // didn't check
-#
 # syncclock
-syncroc3           3    fabc0008   8
-syncroc4           4    fabc0008   8
-syncroc5           5    fabc0008   8
-synctsroc          11   cafe0000   -2
-# syncroc31         31    fabc0008   8 // didn't check
-#
-#
-# On-Board Trigger Supervisor Bits
-scalLive1         11    fed00017   20
-scalLive2         11    fed00017   21
-trigCount         11    fed00017   22
-trigData          11    fed00017   23
+          syncroc1   3    fabc0008   4
+          syncroc2   4    fabc0008   4
+          syncroc3   5    fabc0008   4
+          sycroc4   11    cafe0000   11
 
 DL.crate =
-# L-HRS triggers in TDC
-t1		4	11	48
-t2		4	11	49
-t3		4	11	50
-t4		4	11	51
-t5		4	11	52
-t6		4	11	53
-t7		4	11	54
-t8		4	11	55
-l1a		4	11	62
-
-# Sync ADC (may need to be modified)
-ADCsync3     3  1  0
-ADCsync4     4 16  0
-ADCsync5     5 19  0   
-
-# Shower sum, s0 coin, GC Sum
-s0coin_t    4  11  45
-ShSum_t	    4  11  46
-ShSum_a	    3  20  38
-Sum_1L_a    3  20  36
-Sum_2L_a    3  20  37
-GCSum_a     3  19  10
-GCSum_t	    4  11  42
-
-# Individual Signals
-Cer1	 	  4 11 32
-Cer5	 	  4 11 36
-Cer6	 	  4 11 37
-S2m_9l	 	  4 11 8
-S2m_15r	 	  4 11 30
-S2m_16r	 	  4 11 31
-s0_A	 	  4 11 43
-s0_B	 	  4 11 44
-vdc_ch1	 	  4 8  0
-vdc_ch2	 	  4 8  1
-vdc_ch3	 	  4 8  2
-vdc_ch4	 	  4 8  3
-vdc_ch5	 	  4 8  4
-vdc_ch6	 	  4 8  5
-vdc_ch7	 	  4 8  6
-vdc_ch8	 	  4 8  7
-vdc_ch9	 	  4 8  8
-vdc_ch10 	  4 8  9
-vdc_ch11 	  4 8  10
-vdc_ch12 	  4 8  11
-vdc_ch13 	  4 8  12
-vdc_ch14 	  4 8  13
-vdc_ch15 	  4 8  14
-vdc_ch16 	  4 8  15
-
-# LHRS trigger bit pattern (prescaled)
-bit1             5    16        0 
-bit2             5    16        1
-bit3             5    16        2
-bit4             5    16        3
-bit5             5    16        4
-bit6             5    16        5
-bit7             5    16        6
-bit8             5    16        7
-bit9             5    16        8
-bit10            5    16        9 
-bit11            5    16        10 
-bit12            5    16        11
-#
-# No Connection attached to slot 12
-# LHRS trigger latch pattern
-lbit1             5    16      16 
-lbit2             5    16      17 
-lbit3             5    16      18
-lbit4             5    16      19 
-lbit5             5    16      20 
-lbit6             5    16      21 
-lbit7             5    16      22 
-lbit8             5    16      23 
-lbit9             5    16      24 
-lbit10            5    16      25 
-lbit11            5    16      26 
-lbit12            5    16      27 
-
-D.old =
-/////////# These need to be modified
-# fastclk 	 4	11	56
-# adcgate 	 4	11	57
-# l1a_L	  	 4	11	58
-# strobe  	 4	11	59
-# edtpl   	 4	11	62
+# L-HRS, R-HRS, BB & HAND trigger inputs (1877) left arm copy
+         T1             5      16      0
+         T2             5      16      1
+         T3             5      16      2
+         T4             5      16      3
+         T5             5      16      4
+         T6             5      16      5
+         T7             5      16      6
+         T8             5      16      7
+	 	lt1	     		4		11		48
+	 	lt2		 		4		11		49
+	 	lt3			 	4		11		50
+	 	lt4		 		4		11		51
+	 	lt5			 	4		11		52
+	 	lt6			 	4		11		53
+	 	lt7			 	4		11		54
+	 	lttt8		 	4		11		55
+DL.bit =
+# BIT PATTERN         
+bit1            5    16      0   0  20000
+bit2            5    16      1   0  20000 
+bit3            5    16      2   0  20000
+bit4            5    16      3   0  20000
+bit5            5    16      4   0  20000
+bit6            5    16      5   0  20000
+bit7            5    16      6   0  20000
+bit8            5    16      7   0  20000
+#         bit1            4    11      48   0  2000
+#         bit2            4    11      49   0  2000
+#         bit3            4    11      50   0  2000
+#         bit4            4    11      51   0  2000
+#         bit5            4    11      52   0  2000
+#         bit6            4    11      53   0  2000
+#         bit7            4    11      54   0  2000
+#         bit8            4    11      55   0  2000

--- a/replay/DB/db_DL.dat.bak
+++ b/replay/DB/db_DL.dat.bak
@@ -1,0 +1,135 @@
+# This must be on the first line:  Version: 2
+# Example decoder data definition file
+# Taken from December 2012 online replay database
+# See THaDecData.C for documentation.
+
+DL.word =
+# event number
+evtroc3           3    fabc0008   4
+evtroc4           4    fabc0008   4
+evtroc5           5    fabc0008   4
+evttsroc          11   cafe0000   1
+# evtroc31         31    fabc0008   4 // didn't check
+#
+# event type
+evtyperoc3           3    fabc0008   5
+evtyperoc4           4    fabc0008   5
+evtyperoc5           5    fabc0008   5
+evtypetsroc          11   cafe0000   -8
+# evtyperoc31         31    fabc0008   5 // didn't check
+#
+# event count
+evtcntroc3           3    fabc0008   6
+evtcntroc4           4    fabc0008   6
+evtcntroc5           5    fabc0008   6
+# evtcntroc31         31    fabc0008   6 // didn't check
+#
+# vxclock
+vxroc3           3    fabc0008   7
+vxroc4           4    fabc0008   7
+vxroc5           5    fabc0008   7
+vxtsroc          11   cafe0000   -4
+# vxroc31         31    fabc0008   7 // didn't check
+#
+# syncclock
+syncroc3           3    fabc0008   8
+syncroc4           4    fabc0008   8
+syncroc5           5    fabc0008   8
+synctsroc          11   cafe0000   -2
+# syncroc31         31    fabc0008   8 // didn't check
+#
+#
+# On-Board Trigger Supervisor Bits
+scalLive1         11    fed00017   20
+scalLive2         11    fed00017   21
+trigCount         11    fed00017   22
+trigData          11    fed00017   23
+
+DL.crate =
+# L-HRS triggers in TDC
+t1		4	11	48
+t2		4	11	49
+t3		4	11	50
+t4		4	11	51
+t5		4	11	52
+t6		4	11	53
+t7		4	11	54
+t8		4	11	55
+l1a		4	11	62
+
+# Sync ADC (may need to be modified)
+ADCsync3     3  1  0
+ADCsync4     4 16  0
+ADCsync5     5 19  0   
+
+# Shower sum, s0 coin, GC Sum
+s0coin_t    4  11  45
+ShSum_t	    4  11  46
+ShSum_a	    3  20  38
+Sum_1L_a    3  20  36
+Sum_2L_a    3  20  37
+GCSum_a     3  19  10
+GCSum_t	    4  11  42
+
+# Individual Signals
+Cer1	 	  4 11 32
+Cer5	 	  4 11 36
+Cer6	 	  4 11 37
+S2m_9l	 	  4 11 8
+S2m_15r	 	  4 11 30
+S2m_16r	 	  4 11 31
+s0_A	 	  4 11 43
+s0_B	 	  4 11 44
+vdc_ch1	 	  4 8  0
+vdc_ch2	 	  4 8  1
+vdc_ch3	 	  4 8  2
+vdc_ch4	 	  4 8  3
+vdc_ch5	 	  4 8  4
+vdc_ch6	 	  4 8  5
+vdc_ch7	 	  4 8  6
+vdc_ch8	 	  4 8  7
+vdc_ch9	 	  4 8  8
+vdc_ch10 	  4 8  9
+vdc_ch11 	  4 8  10
+vdc_ch12 	  4 8  11
+vdc_ch13 	  4 8  12
+vdc_ch14 	  4 8  13
+vdc_ch15 	  4 8  14
+vdc_ch16 	  4 8  15
+
+# LHRS trigger bit pattern (prescaled)
+bit1             5    16        0 
+bit2             5    16        1
+bit3             5    16        2
+bit4             5    16        3
+bit5             5    16        4
+bit6             5    16        5
+bit7             5    16        6
+bit8             5    16        7
+bit9             5    16        8
+bit10            5    16        9 
+bit11            5    16        10 
+bit12            5    16        11
+#
+# No Connection attached to slot 12
+# LHRS trigger latch pattern
+lbit1             5    16      16 
+lbit2             5    16      17 
+lbit3             5    16      18
+lbit4             5    16      19 
+lbit5             5    16      20 
+lbit6             5    16      21 
+lbit7             5    16      22 
+lbit8             5    16      23 
+lbit9             5    16      24 
+lbit10            5    16      25 
+lbit11            5    16      26 
+lbit12            5    16      27 
+
+D.old =
+/////////# These need to be modified
+# fastclk 	 4	11	56
+# adcgate 	 4	11	57
+# l1a_L	  	 4	11	58
+# strobe  	 4	11	59
+# edtpl   	 4	11	62

--- a/replay/DB/db_DL.dat~
+++ b/replay/DB/db_DL.dat~
@@ -1,0 +1,135 @@
+# This must be on the first line:  Version: 2
+# Example decoder data definition file
+# Taken from December 2012 online replay database
+# See THaDecData.C for documentation.
+
+DL.word =
+# event number
+evtroc3           3    fabc0008   4
+evtroc4           4    fabc0008   4
+evtroc5           5    fabc0008   4
+evttsroc          11   cafe0000   1
+# evtroc31         31    fabc0008   4 // didn't check
+#
+# event type
+evtyperoc3           3    fabc0008   5
+evtyperoc4           4    fabc0008   5
+evtyperoc5           5    fabc0008   5
+evtypetsroc          11   cafe0000   -8
+# evtyperoc31         31    fabc0008   5 // didn't check
+#
+# event count
+evtcntroc3           3    fabc0008   6
+evtcntroc4           4    fabc0008   6
+evtcntroc5           5    fabc0008   6
+# evtcntroc31         31    fabc0008   6 // didn't check
+#
+# vxclock
+vxroc3           3    fabc0008   7
+vxroc4           4    fabc0008   7
+vxroc5           5    fabc0008   7
+vxtsroc          11   cafe0000   -4
+# vxroc31         31    fabc0008   7 // didn't check
+#
+# syncclock
+syncroc3           3    fabc0008   8
+syncroc4           4    fabc0008   8
+syncroc5           5    fabc0008   8
+synctsroc          11   cafe0000   -2
+# syncroc31         31    fabc0008   8 // didn't check
+#
+#
+# On-Board Trigger Supervisor Bits
+scalLive1         11    fed00017   20
+scalLive2         11    fed00017   21
+trigCount         11    fed00017   22
+trigData          11    fed00017   23
+
+DL.crate =
+# L-HRS triggers in TDC
+t1		4	11	48
+t2		4	11	49
+t3		4	11	50
+t4		4	11	51
+t5		4	11	52
+t6		4	11	53
+t7		4	11	54
+t8		4	11	55
+l1a		4	11	62
+
+# Sync ADC (may need to be modified)
+ADCsync3     3  1  0
+ADCsync4     4 16  0
+ADCsync5     5 19  0   
+
+# Shower sum, s0 coin, GC Sum
+s0coin_t    4  11  45
+ShSum_t	    4  11  46
+ShSum_a	    3  20  38
+Sum_1L_a    3  20  36
+Sum_2L_a    3  20  37
+GCSum_a     3  19  10
+GCSum_t	    4  11  42
+
+# Individual Signals
+Cer1	 	  4 11 32
+Cer5	 	  4 11 36
+Cer6	 	  4 11 37
+S2m_9l	 	  4 11 8
+S2m_15r	 	  4 11 30
+S2m_16r	 	  4 11 31
+s0_A	 	  4 11 43
+s0_B	 	  4 11 44
+vdc_ch1	 	  4 8  0
+vdc_ch2	 	  4 8  1
+vdc_ch3	 	  4 8  2
+vdc_ch4	 	  4 8  3
+vdc_ch5	 	  4 8  4
+vdc_ch6	 	  4 8  5
+vdc_ch7	 	  4 8  6
+vdc_ch8	 	  4 8  7
+vdc_ch9	 	  4 8  8
+vdc_ch10 	  4 8  9
+vdc_ch11 	  4 8  10
+vdc_ch12 	  4 8  11
+vdc_ch13 	  4 8  12
+vdc_ch14 	  4 8  13
+vdc_ch15 	  4 8  14
+vdc_ch16 	  4 8  15
+
+# LHRS trigger bit pattern (prescaled)
+bit1             5    16        0 
+bit2             5    16        1
+bit3             5    16        2
+bit4             5    16        3
+bit5             5    16        4
+bit6             5    16        5
+bit7             5    16        6
+bit8             5    16        7
+bit9             5    16        8
+bit10            5    16        9 
+bit11            5    16        10 
+bit12            5    16        11
+#
+# No Connection attached to slot 12
+# LHRS trigger latch pattern
+lbit1             5    16      16 
+lbit2             5    16      17 
+lbit3             5    16      18
+lbit4             5    16      19 
+lbit5             5    16      20 
+lbit6             5    16      21 
+lbit7             5    16      22 
+lbit8             5    16      23 
+lbit9             5    16      24 
+lbit10            5    16      25 
+lbit11            5    16      26 
+lbit12            5    16      27 
+
+D.old =
+/////////# These need to be modified
+# fastclk 	 4	11	56
+# adcgate 	 4	11	57
+# l1a_L	  	 4	11	58
+# strobe  	 4	11	59
+# edtpl   	 4	11	62

--- a/replay/DB/db_DR.dat.bak
+++ b/replay/DB/db_DR.dat.bak
@@ -1,0 +1,154 @@
+# This must be on the first line:  Version: 2
+# Example decoder data definition file
+# Taken from December 2012 online replay database
+# See THaDecData.C for documentation.
+
+DR.word =
+# event type
+	evtyperoc5           5    fabc0009   6
+	evtyperoc8           8    fabc0008   5
+	evtyperoc9           9    fabc0008   5
+	evtyperoc10         10    fabc0008   5
+# event count
+	evtcntroc5           5    fabc0009   7
+	evtcntroc8           8    fabc0008   6
+	evtcntroc9           9    fabc0008   6
+	evtcntroc10         10    fabc0008   6
+# vxclock
+	vxroc5           5    fabc0009   8
+	vxroc8           8    fabc0008   7
+	vxroc9           9    fabc0008   7
+	vxroc10         10    fabc0008   7
+# syncclock
+	syncroc1           1    fabc0008   8
+	syncroc2           2    fabc0008   8
+	syncroc3           3    fabc0008   8
+	syncroc4           4    fabc0008   8
+	syncroc5           5    fabc0008   8
+	syncroc6           6    fabc0008   8
+	syncroc8           8    fabc0008   8
+	syncroc9           9    fabc0008   8
+	syncroc10         10    fabc0008   8
+# Deadtime Calculations
+        R1start	1	0xdeaddead	1
+        R1stop	1	0xdeaddead	2
+        R2start	2	0xdeaddead	1
+        R2stop	2	0xdeaddead	2
+	R3start	3	0xdeaddead	1
+	R3stop	3	0xdeaddead	2
+	R4start	4	0xdeaddead	1
+	R4stop	4	0xdeaddead	2
+	BBTSstart	29	0xdeaddead	1
+	BBTSstop	29	0xdeaddead	2
+	R10start	10	0xdeaddead	1
+	R10stop	10	0xdeaddead	2
+	5time2	5	0xfaaa0001	-1
+	10time2	10	0xfaaa0001	-1
+	evtroc5           5    fabc0009   5
+	evtroc8           8    fabc0008   4
+	evtroc9           9    fabc0008   4
+	evtroc10         10    fabc0008   4
+#
+
+
+DR.multi =
+# L-HRS, R-HRS, BB & HAND trigger inputs (1877) left arm copy
+	 lt1	     	 4	23	64
+	 lt2		 4	23	65
+	 lt3		 4	23	66
+	 lt4		 4	23	67
+	 lt5		 4	23	68
+	 lt6		 4	23	69
+	 lt7		 4	23	70
+	 lt8		 4	23	71
+	 lfastclk	 4	23	73
+	 adcgate	 4	23	75
+	 l1a_L		 4	23	76
+	 strobe		 4	23	77
+	 s1or		 4	23	78
+	 s2or		 4	23	79
+# Electronic deadtime
+	 edtpl		 4	23	74
+	 edtpr   	 2	11	58
+# Coincidence time
+	 ctimel  	 4	23	72
+	 ctimer  	 2	11	56
+DR.crate =
+# R-HRS trigger inputs (1877)
+	t1		2	11	48
+	t2		2	11	49
+	t3		2	11	50
+	t4		2	11	51
+	t5		2	11	52
+	t6		2	11	53
+	t7		2	11	54
+	t8		2	11	55
+	l1a		2	11	60
+	tdcgate 	2	11	61
+	t12       	2       11      59
+# L-HRS trigger bits
+	left1		4	11	48
+	left2		4	11	49
+	left3		4	11	50
+	left4		4	11	51
+	left5		4	11	52
+	left6		4	11	53
+	left7		4	11	54
+	left8		4	11	55
+	leftl1a		4	11	62
+# BPM and raster on right arm  ROC1
+	# bpmaxp             1    22       0
+	# bpmaxm             1    22       1
+	# bpmayp             1    22       2
+	# bpmaym             1    22       3
+	# bpmbxp             1    22       4
+	# bpmbxm             1    22       5
+	# bpmbyp             1    22       6
+	# bpmbym             1    22       7
+	# rasterx            1    22       8
+	# rastery            1    22       9
+# Sync ADC
+	ADCsync1   1 18  1
+	ADCsync2   2 16  0
+	ADCsync6   6 20  0
+# Shower sum , GC Sum and s0 coin
+	s0coin_t      2  11  45
+	ShSum_t       2  11  46
+	ShSum_a       1  20  45
+	GCsum_a       1  20  42
+	GCsum_t       2  11  42
+# Individual Channels
+	Cer1  2 11 32
+	Cer5  2 11 36
+	Cer6  2 11 37
+	s0_A  2 11 43
+	s0_B  2 11 44
+# Retiming from the LHRS on the right side
+	Retiming_L  2 11 47
+# RHRS trigger bit pattern (prescaled)
+	bit1             6    16       48
+	bit2             6    16       49
+	bit3             6    16       50
+	bit4             6    16       51
+	bit5             6    16       52
+	bit6             6    16       53
+	bit7             6    16       54
+	bit8             6    16       55
+	bit9             6    16       56
+	bit10            6    16       57
+	bit11            6    16       58
+	bit12            6    16       59
+# No Connection attached to slot 60
+# RHRS trigger latch pattern
+	lbit1            6     16      64 
+	lbit2            6     16      65
+	lbit3            6     16      66
+	lbit4            6     16      67
+	lbit5            6     16      68
+	lbit6            6     16      69
+	lbit7            6     16      70
+	lbit8            6     16      71
+	lbit9            6     16      72
+	lbit10           6     16      73
+	lbit11           6     16      74
+	lbit12           6     16      75

--- a/replay/DB/db_DR.dat~
+++ b/replay/DB/db_DR.dat~
@@ -3,7 +3,7 @@
 # Taken from December 2012 online replay database
 # See THaDecData.C for documentation.
 
-DR.word =
+rhrs.word =
 # syncclock
           syncroc1   5    fabc0009   5
           syncroc2   8    fabc0008   4
@@ -25,7 +25,7 @@ DR.word =
 	  5time2	5	0xfaaa0001	-1
 	  10time2	10	0xfaaa0001	-1
 
-DR.multi =
+rhrs.multi =
 # L-HRS, R-HRS, BB & HAND trigger inputs (1877) left arm copy
 	 t1	     	 2	11	48
 	 t2		 2	11	49
@@ -35,7 +35,7 @@ DR.multi =
 	 t6		 2	11	53
 	 t7		 2	11	54
 	 t8		 2	11	55
-DR.bit =
+rhrs.bit =
          bit1          6    16    48    0  2000
          bit2          6    16    49    0  2000  
          bit3          6    16    50    0  2000

--- a/replay/replay_tritium.C
+++ b/replay/replay_tritium.C
@@ -28,9 +28,8 @@ void replay_tritium(Int_t runnumber=0,Int_t all=50000,Int_t fstEvt=0,Bool_t Quie
 	    cin >> nrun;
 	    fgets(buf,300,stdin);//get the extra '\n' from stdin
 	    if( nrun<=0 ) return;
-	    runnumber = nrun;
   }
-
+  runnumber = nrun;
   
   //Enable modules
   Bool_t bScaler=kTRUE;


### PR DESCRIPTION
Used Tongs fixes to the Database to fix the git replay. I move the old decoder DBs to a backup version so we can still use them to add and compare in the future. The new DR and DL databases are used in the evtypebits. 