### PR TITLE
Output switched away from /home, fastbus in odef, onlineGUI compiles

### DIFF
--- a/replay/LHRS.odef
+++ b/replay/LHRS.odef
@@ -8,6 +8,10 @@ block L.cer.*
 block L.vdc.*
 block L.tr.*
 
+block FbusL.s0.*
+block FbusL.s2.*
+block FbusL.cer.*
+
 block DL.*
 
 # Physics variables

--- a/replay/RHRS.odef
+++ b/replay/RHRS.odef
@@ -7,6 +7,10 @@ block R.cer.*
 block R.vdc.*
 block R.tr.*
 
+block FbusR.s0.*
+block FbusR.s2.*
+block FbusR.cer.*
+
 block DR.*
 
 # Physics variables

--- a/replay/def_tritium.h
+++ b/replay/def_tritium.h
@@ -37,7 +37,7 @@
 //Used for setting paths. %s is necessary so that it can be used to Form the paths.
 //This allows changing the directory in fewer places for ease of portability.
 const char* REPLAY_DIR_PREFIX = "/adaqfs/home/a-onl/tritium/replay/%s";
-const char* ROOTFILE_DIR_PREFIX = "/chafs/work1/tritium/%s";
+const char* ROOTFILE_DIR_PREFIX = "/chafs1/work1/tritium/%s";
 
 typedef struct _sReplaySetUp
 {

--- a/replay/def_tritium.h
+++ b/replay/def_tritium.h
@@ -37,6 +37,7 @@
 //Used for setting paths. %s is necessary so that it can be used to Form the paths.
 //This allows changing the directory in fewer places for ease of portability.
 const char* REPLAY_DIR_PREFIX = "/adaqfs/home/a-onl/tritium/replay/%s";
+const char* ROOTFILE_DIR_PREFIX = "/chafs/work1/tritium/%s";
 
 typedef struct _sReplaySetUp
 {
@@ -66,11 +67,11 @@ static const char* PATHS[] = {
    0
 };
 
-static const char* RAW_DATA_FORMAT="%s/gmp_%d.dat.%d";
+static const char* RAW_DATA_FORMAT="%s/triton_%d.dat.%d";
 //static const char* RAW_DATA_FORMAT="%s/dvcs14_%d.dat.%d";
 
-static const char* STD_REPLAY_OUTPUT_DIR=Form(REPLAY_DIR_PREFIX,"Rootfiles");
-static const char* CUSTOM_REPLAY_OUTPUT_DIR=Form(REPLAY_DIR_PREFIX,"ScratchROOTfiles");
+static const char* STD_REPLAY_OUTPUT_DIR=Form(ROOTFILE_DIR_PREFIX,"Rootfiles");
+static const char* CUSTOM_REPLAY_OUTPUT_DIR=Form(ROOTFILE_DIR_PREFIX,"ScratchROOTfiles");
 
 static const char* SUMMARY_PHYSICS_FORMAT=Form(REPLAY_DIR_PREFIX,"summaryfiles/summaryphy_%d.log");
 

--- a/replay/onlineGUI64/Makefile
+++ b/replay/onlineGUI64/Makefile
@@ -18,7 +18,7 @@ GLIBS         = $(ROOTGLIBS) -L/usr/lib64/libXpm.so.4 -L/usr/lib64 -lX11
 LIBS          = $(GLIBS) $(ROOTLIBS) $(ROOTGLIBS)
 
 CXX           = $(GCC)
-CXXFLAGS      = -Wall -fno-exceptions -fPIC $(INCLUDES) -fpermissive
+CXXFLAGS      = -Wall -fno-exceptions -fPIC $(INCLUDES) -fpermissive -std=c++11
 LD            = $(GLD)
 LDFLAGS       = 
 MAKEDEPEND    = $(GCC)
@@ -93,7 +93,7 @@ realclean:  clean
 
 %.d:	%.C
 	@echo Creating dependencies for $<
-	@$(SHELL) -ec '$(MAKEDEPEND) -MM $(INCLUDES) -c $< \
+	@$(SHELL) -ec '$(MAKEDEPEND) -std=c++11 -MM $(INCLUDES) -c $< \
 	      | sed '\''s%^.*\.o%$*\.o%g'\'' \
 	      | sed '\''s%\($*\)\.o[ :]*%\1.o $@ : %g'\'' > $@; \
 	      [ -s $@ ] || rm -f $@'

--- a/replay/onlineGUI64/Makefile
+++ b/replay/onlineGUI64/Makefile
@@ -30,7 +30,7 @@ ifdef ANALYZER
     INCLUDES     += $(addprefix -I, $(INCDIRS) )
   endif
   ifneq ($(strip $(LIBS)),)
-    LIBS         += $(addprefix -L, $(LIBDIRS) ) -lHallA -ldc -lscaler
+    LIBS         += $(addprefix -L, $(LIBDIRS) )
   endif
 endif
 


### PR DESCRIPTION
Output now defaults to directory on /chafs that Jason set up.
Fastbus copies of Flash ADC data is now in the odef file
onlineGUI Makefile has been updated so that it will compile. Some analyzer flags were deprecated, as far as I can tell. Also needed a `-std=c++11` flag to compile correctly.