### PR TITLE
Updated the xscaler GUI to for swapping RHRS scaler 3 Ch14 (L1A) with ch15 (FastBus_remote) and same for scaler 1.

### DIFF
--- a/scaler/scaler.map
+++ b/scaler/scaler.map
@@ -265,8 +265,8 @@ S2L           0   7     1     10   1
 S2R	      0   7     1     11   1 
 (S0||S2)R     0   7     1     12   1 
 ADC_gate      0   7     1     13   1
-L1A           0   7     1     14   1
-FastBus_remote  0   7     1     15   1 
+FastBus_remote  0   7     1     14   1   
+L1A             0   7     1     15   1 
 Cher-1          0   7     1    16    1      1st chan of cerenkov
 Cher-2          0   7     1    17    1
 Cher-3          0   7     1    18    1      Right HRS
@@ -342,8 +342,8 @@ S2L           0   7     3     10   1
 S2R           0   7     3     11   1
 (S0||S2)R     0   7     3     12   1
 ADC_gate      0   7     3     13   1
-L1A           0   7     3     14   1
-FastBus_remote  0   7     3     15   1
+Broken        0   7     3     14   1      Currently broken. Will was FastBus_remote
+L1A           0   7     3     15   1
 unew          0   7     3     18    1
 dnew          0   7     3     20    1
 unser         0   7     3     22    1


### PR DESCRIPTION
RHRS Scaler 3 and 1 had channels 14 (L1A) and 15 (Fastbus_remote) swapped to avoid using scaler 3 channel 14 for L1A as that channel is currently broken. I have not yet updated the relevant databases to reflect this channel swap. I will determine what needs to be changed in the databases, but probably not before tomorrow afternoon.