### PR TITLE
use fastclock from LHRS instead of the slow RHRS clock for scaler frequency calculation

### DIFF
--- a/replay/DB/db_RightScalevt.dat
+++ b/replay/DB/db_RightScalevt.dat
@@ -7,7 +7,7 @@
 
 map 3800 7 1 ceb10000 ffff0000 3 
 map 3800 7 2 ceb20000 ffff0000 3 
-map 3800 7 3 ceb30000 ffff0000 3 9 1024 
+map 3800 7 3 ceb30000 ffff0000 3 7 103700
 
 
 # variable syntax

--- a/replay/DB/db_evRightScalevt.dat
+++ b/replay/DB/db_evRightScalevt.dat
@@ -5,7 +5,7 @@
 # scaler, type, crate, slot, header, mask, norm slot#
 # after the norm slot#:  clock chan# and clock frequency
 
-map 3800 7 3 ceb30020 ffffffff 3 9 1024 
+map 3800 7 3 ceb30020 ffffffff 3 7 103700
 
 
 # variable syntax


### PR DESCRIPTION
use fastclock from LHRS instead of the slow RHRS clock for RHRS scaler frequency calculation