### PR TITLE
added V1495ClockInterval. Updated V1495 slots

### DIFF
--- a/replay/DB/db_cratemap.dat
+++ b/replay/DB/db_cratemap.dat
@@ -80,16 +80,16 @@
        8      250      250
        9      250      250
       16     3204        8
-      21     1495     1495
+      18     1495     1495
 ==== Crate 20 type vme 
 #      slot     model   bank
+        4     1495     1495
         8     3204        8
        13      250      250
        14      250      250
        15      250      250
        16      250      250
        19     1984        7
-       20     1495     1495
 ==== Crate 11 type scaler "evleft" 
 #      slot	model	clear	header	mask	nchan	ndata
    	1	3801	1	0xabc10000	0xffff0000	32	32

--- a/replay/LHRS.odef
+++ b/replay/LHRS.odef
@@ -23,6 +23,7 @@ variable F1AllHits_033
 
 # V1495 Clock Count
 variable V1495ClockCount
+variable V1495ClockInterval
 
 # Physics variables
 block L.gold.*

--- a/replay/RHRS.odef
+++ b/replay/RHRS.odef
@@ -24,6 +24,7 @@ variable vfAllHits_126
 
 # V1495 Clock Count
 variable V1495ClockCount
+variable V1495ClockInterval
 
 # Physics variables
 block RightBCM*

--- a/replay/libraries/TriV1495/ClockCountEvtHandler.cxx
+++ b/replay/libraries/TriV1495/ClockCountEvtHandler.cxx
@@ -74,11 +74,11 @@ Int_t ClockCountEvtHandler::Analyze(THaEvData *evdata)
 
 
   // FIXME: Not getting the crate/slot numbers automatically yet. Hardcoding them for now.
-  if(nameArm1495=="LV1495") { // LEFT HRS (ROC31, slot 14 and 16):  
-    V1495 = dynamic_cast <Decoder::V1495Module* > (evdata->GetModule(31,21));	//FIXME: Need to get the actual slots for V1495s
+  if(nameArm1495=="LV1495") { // LEFT HRS (ROC31, slot 18):  
+    V1495 = dynamic_cast <Decoder::V1495Module* > (evdata->GetModule(31,18));	//FIXME: Need to get the actual slots for V1495s
   }
-  else if(nameArm1495=="RV1495") { // RIGHT HRS:
-    V1495 = dynamic_cast <Decoder::V1495Module* > (evdata->GetModule(20,20));	//FIXME: Need to get the actual slots for V1495s
+  else if(nameArm1495=="RV1495") { // RIGHT HRS (ROC20, slot 4):
+    V1495 = dynamic_cast <Decoder::V1495Module* > (evdata->GetModule(20,4));	//FIXME: Need to get the actual slots for V1495s
   }
   else cout << "Did not recognize name of ClockCountEvtHandler decoder. Please call it using RV1495 or LV1495 to decode Clock Counter." << endl;
 
@@ -175,10 +175,13 @@ if(ldebug) {
   }
 
 if(V1495!=0){
+	V1495PrevCount = V1495ClockCount;
 	V1495ClockCount = 0;
 	if (fDebug) cout << "Before V1495->GetCount()     V1495ClockCount = " << hex << V1495ClockCount << dec << endl;
 	V1495ClockCount = V1495->GetCount();
 	if (fDebug) cout << "After V1495->GetCount()      V1495ClockCount = " << hex << V1495ClockCount << dec << endl;
+	V1495ClockInterval = 0;
+	V1495ClockInterval = V1495ClockCount - V1495PrevCount;
 }
 
   return 1;
@@ -198,6 +201,7 @@ THaAnalysisObject::EStatus ClockCountEvtHandler::Init(const TDatime& date)
 
   // data keys to look for in this fun example
   dataKeys.push_back("V1495ClockCount");
+  dataKeys.push_back("V1495ClockInterval");
 
   // initialize map elements to -1 (means not found yet)
   for (UInt_t i=0; i < dataKeys.size(); i++) {
@@ -223,6 +227,10 @@ THaAnalysisObject::EStatus ClockCountEvtHandler::Init(const TDatime& date)
   // for Clock Count
   V1495ClockCount = 0;
   gHaVars->DefineByType(dataKeys[numEntries].c_str(), "V1495ClockCount", &V1495ClockCount, kUInt, 0);
+  numEntries++;
+  // for Clock Interval
+  V1495ClockInterval = 0;
+  gHaVars->DefineByType(dataKeys[numEntries].c_str(), "V1495ClockInterval", &V1495ClockInterval, kUInt, 0);
   numEntries++;
   
   fStatus = kOK;

--- a/replay/libraries/TriV1495/ClockCountEvtHandler.h
+++ b/replay/libraries/TriV1495/ClockCountEvtHandler.h
@@ -35,6 +35,8 @@ private:
    Double_t *dvars;
    //V1495
    UInt_t V1495ClockCount;
+   UInt_t V1495PrevCount;
+   UInt_t V1495ClockInterval;
 
    ClockCountEvtHandler(const ClockCountEvtHandler& fh);
    ClockCountEvtHandler& operator=(const ClockCountEvtHandler& fh);


### PR DESCRIPTION
-added V1495ClockInterval calculation to TriV1495 library
	-For each event, this is the elapsed clock count since the last
event
-added V1495ClockInterval variable to RHRS.odef and LHRS.odef
-updated the slot numbers for the v1495 in each arm in the cratemap.
	-LHRS ROC31 slot 18, RHRS ROC20 slot 4