### PR TITLE
wiki_runlist can be given a range

### DIFF
--- a/replay/scripts/wiki_runlist
+++ b/replay/scripts/wiki_runlist
@@ -5,9 +5,22 @@ then
 fi
 
 
-for  var in "$@"
-do
-echo adding Run $var
-analyzer -b 'getinfo.C('$var')'
-
-done
+if [ $# -eq 2 ]
+then
+  if [ $2 -gt $1 ]
+  then
+    counter=$1
+    while [ $counter -le $2 ]
+    do
+      echo adding Run $counter
+      analyzer -b 'getinfo.C('$counter')'
+      ((counter++))
+    done
+  fi
+else
+  for  var in "$@"
+  do
+  echo adding Run $var
+  analyzer -b 'getinfo.C('$var')'
+  done
+fi


### PR DESCRIPTION
If you only provide two run numbers to wiki_runlist, it treats them as a range and pulls all run numbers in between.