### PR TITLE
FADC time add;

### DIFF
--- a/replay/libraries/TriFadcCherenkov/TriFadcCherenkov.C
+++ b/replay/libraries/TriFadcCherenkov/TriFadcCherenkov.C
@@ -27,7 +27,7 @@ using namespace Decoder;
 TriFadcCherenkov::TriFadcCherenkov( const char* name, const char* description,
 			    THaApparatus* apparatus )
   : THaPidDetector(name,description,apparatus), fOff(0), fPed(0), fGain(0),
-    fNThit(0), fT(0), fT_c(0), fNAhit(0), fA(0), fA_p(0), fA_c(0),fT_FADC(0),fT_FADC_c(0),
+    fNThit(0), fT(0), fT_c(0), fNAhit(0), fA(0), fA_p(0), fA_c(0),fPeak(0),fT_FADC(0),fT_FADC_c(0),
     foverflow(0), funderflow(0),fpedq(0),fNhits(0)
 {
   // Constructor
@@ -37,7 +37,7 @@ TriFadcCherenkov::TriFadcCherenkov( const char* name, const char* description,
 //_____________________________________________________________________________
 TriFadcCherenkov::TriFadcCherenkov()
   : THaPidDetector(), fOff(0), fPed(0), fGain(0), fT(0), fT_c(0),
-    fA(0), fA_p(0), fA_c(0),fT_FADC(0),fT_FADC_c(0),foverflow(0), funderflow(0),fpedq(0),fNhits(0)
+    fA(0), fA_p(0), fA_c(0),fPeak(0),fT_FADC(0),fT_FADC_c(0),foverflow(0), funderflow(0),fpedq(0),fNhits(0)
 {
   // Default constructor (for ROOT I/O)
 }
@@ -127,6 +127,7 @@ Int_t TriFadcCherenkov::ReadDatabase( const TDatime& date )
     fA_p  = new Float_t[ nval ];
     fA_c  = new Float_t[ nval ];
 
+    fPeak      = new Float_t[ nval ];
     fT_FADC    = new Float_t[ nval ];
     fT_FADC_c  = new Float_t[ nval ];
     foverflow  = new Int_t[ nval ]; 
@@ -185,6 +186,7 @@ Int_t TriFadcCherenkov::DefineVariables( EMode mode )
     { "a",      "ADC values",                        "fA" },
     { "a_p",    "Ped-subtracted ADC values ",        "fA_p" },
     { "a_c",    "Corrected ADC values",              "fA_c" },
+    { "peak",   "FADC ADC peak values",              "fPeak" },
     { "t_fadc", "FADC TDC values",                   "fT_FADC" },
     { "tc_fadc", "FADC corrected TDC values",        "fT_FADC_c" },
     { "asum_p", "Sum of ADC minus pedestal values",  "fASUM_p" },
@@ -228,6 +230,7 @@ void TriFadcCherenkov::DeleteArrays()
   delete [] fPed;    fPed    = NULL;
   delete [] fOff;    fOff    = NULL;
 
+  delete [] fPeak;      fPeak      = NULL;
   delete [] fT_FADC;    fT_FADC    = NULL;
   delete [] fT_FADC_c;  fT_FADC_c  = NULL;
   delete [] foverflow;  foverflow  = NULL;
@@ -245,6 +248,7 @@ void TriFadcCherenkov::Clear( Option_t* opt )
   assert(fIsInit);
   for( Int_t i=0; i<fNelem; ++i ) {
     fT[i] = fT_c[i] = fA[i] = fA_p[i] = fA_c[i] = 0.0;
+    fPeak[i]=0.0;
     fT_FADC[i]=0.0;
     fT_FADC_c[i]=0.0;
   }
@@ -292,9 +296,11 @@ Int_t TriFadcCherenkov::Decode( const THaEvData& evdata )
       // Get the data. Aero mirrors are assumed to have only single hit (hit=0)
       Int_t data;
       Int_t ftime=0;
+      Int_t fpeak=0;
       if(adc){
 	 data = evdata.GetData(kPulseIntegral,d->crate,d->slot,chan,0);
          ftime = evdata.GetData(kPulseTime,d->crate,d->slot,chan,0);
+         fpeak = evdata.GetData(kPulsePeak,d->crate,d->slot,chan,0);
       }
       else{ 
 	     fNhits[k]=evdata.GetNumHits(d->crate, d->slot, chan);     
@@ -316,6 +322,7 @@ Int_t TriFadcCherenkov::Decode( const THaEvData& evdata )
       // Copy the data to the local variables.
       if ( adc ) {
 	fA[k]   = data;
+        fPeak[k] = static_cast<Float_t>(fpeak);
         fT_FADC[k]=static_cast<Float_t>(ftime);
         fT_FADC_c[k]=fT_FADC[k]*0.0625;
 	fA_p[k] = data - fPed[k];

--- a/replay/libraries/TriFadcCherenkov/TriFadcCherenkov.h
+++ b/replay/libraries/TriFadcCherenkov/TriFadcCherenkov.h
@@ -51,6 +51,8 @@ protected:
   Float_t    fASUM_c;     // Sum of corrected ADC amplitudes of channels
 
   //FADC
+  Float_t*   fT_FADC;       // [fNelem] Array of FADC TDC times of channels
+  Float_t*   fT_FADC_c;     // [fNelem] Array of FADC corrected TDC times of channels
   Int_t* foverflow;         //[fNelem] FADC overflowbit
   Int_t* funderflow;        //[fNelem] FADC underflowbit
   Int_t* fpedq;             //[fNelem] FADC pedestal quality bit

--- a/replay/libraries/TriFadcCherenkov/TriFadcCherenkov.h
+++ b/replay/libraries/TriFadcCherenkov/TriFadcCherenkov.h
@@ -51,6 +51,7 @@ protected:
   Float_t    fASUM_c;     // Sum of corrected ADC amplitudes of channels
 
   //FADC
+  Float_t*   fPeak;         // [fNelem] Array of FADC ADC peak values
   Float_t*   fT_FADC;       // [fNelem] Array of FADC TDC times of channels
   Float_t*   fT_FADC_c;     // [fNelem] Array of FADC corrected TDC times of channels
   Int_t* foverflow;         //[fNelem] FADC overflowbit

--- a/replay/libraries/TriFadcScin/TriFadcScin.cxx
+++ b/replay/libraries/TriFadcScin/TriFadcScin.cxx
@@ -36,7 +36,8 @@ TriFadcScin::TriFadcScin( const char* name, const char* description,
     fLTNhit(0), fLT(0), fLT_c(0), fRTNhit(0), fRT(0), fRT_c(0),
     fLANhit(0), fLA(0), fLA_p(0), fLA_c(0), fRANhit(0), fRA(0), fRA_p(0), fRA_c(0),
     fNhit(0), fHitPad(0), fTime(0), fdTime(0), fAmpl(0), fYt(0), fYa(0), 
-    floverflow(0), flunderflow(0),flpedq(0),froverflow(0), frunderflow(0),frpedq(0),fLNhits(0),fRNhits(0)
+    fLT_FADC(0),fLT_FADC_c(0),floverflow(0), flunderflow(0),flpedq(0),
+    fRT_FADC(0),fRT_FADC_c(0),froverflow(0),frunderflow(0),frpedq(0),fLNhits(0),fRNhits(0)
 {
   // Constructor
   fFADC = NULL;
@@ -48,7 +49,8 @@ TriFadcScin::TriFadcScin()
     fLGain(0), fRGain(0), fTWalkPar(0), fAdcMIP(0), fTrigOff(0),
     fLT(0), fLT_c(0), fRT(0), fRT_c(0), fLA(0), fLA_p(0), fLA_c(0),
     fRA(0), fRA_p(0), fRA_c(0), fHitPad(0), fTime(0), fdTime(0), fAmpl(0),
-    fYt(0), fYa(0),floverflow(0), flunderflow(0),flpedq(0),froverflow(0), frunderflow(0),frpedq(0),
+    fYt(0), fYa(0),fLT_FADC(0),fLT_FADC_c(0),floverflow(0), flunderflow(0),flpedq(0),
+    fRT_FADC(0),fRT_FADC_c(0),froverflow(0), frunderflow(0),frpedq(0),
     fLNhits(0),fRNhits(0)
 {
   // Default constructor (for ROOT I/O)
@@ -173,10 +175,14 @@ Int_t TriFadcScin::ReadDatabase( const TDatime& date )
     fYt     = new Double_t[ nval ];
     fYa     = new Double_t[ nval ];
 
+    fLT_FADC    = new Double_t[ nval ];
+    fLT_FADC_c = new Double_t[ nval ];
     floverflow  = new Int_t[ nval ];
     flunderflow = new Int_t[ nval ];
     flpedq      = new Int_t[ nval ];
 
+    fRT_FADC    = new Double_t[ nval ];
+    fRT_FADC_c = new Double_t[ nval ];
     froverflow  = new Int_t[ nval ];
     frunderflow = new Int_t[ nval ];
     frpedq      = new Int_t[ nval ];
@@ -297,6 +303,10 @@ Int_t TriFadcScin::DefineVariables( EMode mode )
     { "trpath", "TRCS pathlen of track to det plane","fTrackProj.THaTrackProj.fPathl" },
     { "trdx",   "track deviation in x-position (m)", "fTrackProj.THaTrackProj.fdX" },
     { "trpad",  "paddle-hit associated with track",  "fTrackProj.THaTrackProj.fChannel" },
+    { "lt_fadc",   "FADC TDC values left side",      "fLT_FADC" },
+    { "ltc_fadc",  "FADC Corrected times left side", "fLT_FADC_c" },
+    { "rt_fadc",   "FADC TDC values right side",      "fRT_FADC" },
+    { "rtc_fadc",  "FADC Corrected times right side", "fRT_FADC_c" },
     { "loverflow",  "overflow bit of FADC pulse",    "floverflow" },
     { "lunderflow",  "underflow bit of FADC pulse",  "flunderflow" },
     { "lbadped",  "pedestal quality bit of FADC pulse",   "flpedq" },
@@ -353,6 +363,10 @@ void TriFadcScin::DeleteArrays()
   delete [] fYt;      fYt      = NULL;
   delete [] fYa;      fYa      = NULL;
 
+  delete [] fLT_FADC_c;  fLT_FADC_c  = NULL;
+  delete [] fLT_FADC;    fLT_FADC    = NULL;
+  delete [] fRT_FADC_c;  fRT_FADC_c  = NULL;
+  delete [] fRT_FADC;    fRT_FADC    = NULL;
   delete [] floverflow;  floverflow  = NULL;
   delete [] flunderflow; flunderflow = NULL;
   delete [] flpedq;      flpedq      = NULL;
@@ -372,6 +386,7 @@ void TriFadcScin::Clear( Option_t* opt )
   assert(fIsInit);
   for( Int_t i=0; i<fNelem; ++i ) {
     fLT[i] = fLT_c[i] = fRT[i] = fRT_c[i] = 0;
+    fLT_FADC[i] = fLT_FADC_c[i] = fRT_FADC[i] = fRT_FADC_c[i] = 0;
     fLA[i] = fLA_p[i] = fLA_c[i] = fRA[i] = fRA_p[i] = fRA_c[i] = 0;
     fTime[i] = fdTime[i] = fAmpl[i] = fYt[i] = fYa[i] = 0;
   }
@@ -437,8 +452,11 @@ Int_t TriFadcScin::Decode( const THaEvData& evdata )
       int jj=k/fNelem; 
       k = k % fNelem; 
 
-      Int_t data;
-      if(adc)data = evdata.GetData(kPulseIntegral,d->crate,d->slot,chan,0);
+      Int_t data,ftime;
+      if(adc){
+         data = evdata.GetData(kPulseIntegral,d->crate,d->slot,chan,0);
+         ftime = evdata.GetData(kPulseTime,d->crate,d->slot,chan,0);
+      }
       else {
 	     if(jj==0){
                  fRNhits[k]=evdata.GetNumHits(d->crate, d->slot, chan);
@@ -457,11 +475,15 @@ Int_t TriFadcScin::Decode( const THaEvData& evdata )
                   floverflow[k] = fFADC->GetOverflowBit(chan,0);
                   flunderflow[k] = fFADC->GetUnderflowBit(chan,0);
                   flpedq[k] = fFADC->GetPedestalQuality(chan,0);
+                  fLT_FADC[k]=static_cast<Double_t>(ftime);
+		  fLT_FADC_c[k]=fLT_FADC[k]*0.0625;
               }
              else {
                   froverflow[k]=fFADC->GetOverflowBit(chan,0);
                   frunderflow[k]=fFADC->GetUnderflowBit(chan,0);
                   frpedq[k]=fFADC->GetPedestalQuality(chan,0);
+                  fRT_FADC[k]=static_cast<Double_t>(ftime);
+		  fRT_FADC_c[k]=fRT_FADC[k]*0.0625;
              }
           }
 

--- a/replay/libraries/TriFadcScin/TriFadcScin.h
+++ b/replay/libraries/TriFadcScin/TriFadcScin.h
@@ -108,10 +108,14 @@ protected:
   Double_t*   fYa;         // [fNelem] y-position of hit in paddle from ADC (m)
 
   //FADC
+  Double_t*   fLT_FADC;      // [fNelem] Array of Left paddles FADC TDC times (channels)
+  Double_t*   fLT_FADC_c;    // [fNelem] Array of Left PMT corrected FADC TDC times (s)
   Int_t* floverflow;         //[fNelem] FADC overflowbit
   Int_t* flunderflow;        //[fNelem] FADC underflowbit
   Int_t* flpedq;             //[fNelem] FADC pedestal quality bit
 
+  Double_t*   fRT_FADC;      // [fNelem] Array of right paddles FADC TDC times (channels)
+  Double_t*   fRT_FADC_c;    // [fNelem] Array of right PMT corrected FADC TDC times (s)
   Int_t* froverflow;         //[fNelem] FADC overflowbit
   Int_t* frunderflow;        //[fNelem] FADC underflowbit
   Int_t* frpedq;             //[fNelem] FADC pedestal quality bit

--- a/replay/libraries/TriFadcScin/TriFadcScin.h
+++ b/replay/libraries/TriFadcScin/TriFadcScin.h
@@ -108,12 +108,14 @@ protected:
   Double_t*   fYa;         // [fNelem] y-position of hit in paddle from ADC (m)
 
   //FADC
+  Double_t*   fLPeak;        // [fNelem] Array of Left paddles FADC ADC peak value
   Double_t*   fLT_FADC;      // [fNelem] Array of Left paddles FADC TDC times (channels)
   Double_t*   fLT_FADC_c;    // [fNelem] Array of Left PMT corrected FADC TDC times (s)
   Int_t* floverflow;         //[fNelem] FADC overflowbit
   Int_t* flunderflow;        //[fNelem] FADC underflowbit
   Int_t* flpedq;             //[fNelem] FADC pedestal quality bit
 
+  Double_t*   fRPeak;        // [fNelem] Array of right paddles FADC ADC peak value
   Double_t*   fRT_FADC;      // [fNelem] Array of right paddles FADC TDC times (channels)
   Double_t*   fRT_FADC_c;    // [fNelem] Array of right PMT corrected FADC TDC times (s)
   Int_t* froverflow;         //[fNelem] FADC overflowbit

--- a/replay/libraries/TriFadcXscin/TriFadcXscin.h
+++ b/replay/libraries/TriFadcXscin/TriFadcXscin.h
@@ -102,12 +102,14 @@ protected:
   Int_t*     fHitPad;     // [fNhit] list of paddles with complete TDC hits
 
   //FADC
+  Double_t*   fLPeak;        // [fNelem] Array of Left paddles FADC ADC peak value
   Double_t*   fLT_FADC;      // [fNelem] Array of Left paddles FADC TDC times (channels)
   Double_t*   fLT_FADC_c;    // [fNelem] Array of Left PMT corrected FADC TDC times (s)
   Int_t* floverflow;         //[fNelem] FADC overflowbit
   Int_t* flunderflow;        //[fNelem] FADC underflowbit
   Int_t* flpedq;             //[fNelem] FADC pedestal quality bit
 
+  Double_t*   fRPeak;        // [fNelem] Array of right paddles FADC ADC peak value
   Double_t*   fRT_FADC;      // [fNelem] Array of right paddles FADC TDC times (channels)
   Double_t*   fRT_FADC_c;    // [fNelem] Array of right PMT corrected FADC TDC times (s)
   Int_t* froverflow;         //[fNelem] FADC overflowbit

--- a/replay/libraries/TriFadcXscin/TriFadcXscin.h
+++ b/replay/libraries/TriFadcXscin/TriFadcXscin.h
@@ -102,10 +102,14 @@ protected:
   Int_t*     fHitPad;     // [fNhit] list of paddles with complete TDC hits
 
   //FADC
+  Double_t*   fLT_FADC;      // [fNelem] Array of Left paddles FADC TDC times (channels)
+  Double_t*   fLT_FADC_c;    // [fNelem] Array of Left PMT corrected FADC TDC times (s)
   Int_t* floverflow;         //[fNelem] FADC overflowbit
   Int_t* flunderflow;        //[fNelem] FADC underflowbit
   Int_t* flpedq;             //[fNelem] FADC pedestal quality bit
 
+  Double_t*   fRT_FADC;      // [fNelem] Array of right paddles FADC TDC times (channels)
+  Double_t*   fRT_FADC_c;    // [fNelem] Array of right PMT corrected FADC TDC times (s)
   Int_t* froverflow;         //[fNelem] FADC overflowbit
   Int_t* frunderflow;        //[fNelem] FADC underflowbit
   Int_t* frpedq;             //[fNelem] FADC pedestal quality bit


### PR DESCRIPTION
FADC time added. So far, FADC corrected time is just the raw time *0.0625 count/ns. Needs to think about how the fadc time calibration would be done to adjust the fT_FADC_c. For scintillator class, other advanced variables using time information are probably needed to be changed.