### PR TITLE
clean up roc31 threshold stuff

### DIFF
--- a/replay/rol/roc31_tritium_list.c
+++ b/replay/rol/roc31_tritium_list.c
@@ -146,28 +146,18 @@ rocDownload()
        faEnableBusError(faSlot(islot));
       //  faSetThreshold(faSlot(islot), 0, 0xffff);
       
-     if(WANT_THRESHOLD){
-       for (ifa = 0; ifa<16; ifa++)
-        {
-          thrshflag |= 1 << ifa;
-          if(islot==0) faSetThreshold(faSlot(islot), L1thrshold[ifa]+FADC_THRESHOLD , thrshflag);
-          if(islot==1) faSetThreshold(faSlot(islot), L2thrshold[ifa]+FADC_THRESHOLD , thrshflag);
-          if(islot==2) faSetThreshold(faSlot(islot), L3thrshold[ifa]+FADC_THRESHOLD , thrshflag);
-          if(islot==3) faSetThreshold(faSlot(islot), 1, thrshflag);
-  
-          thrshflag = chan_mask;    
-	} 
-     }
-          
-   else{
-      if(islot==2){           
-            faSetThreshold(faSlot(islot), 1, 0xdfff); //0xffff sets all channels to same threshold
-            faSetThreshold(faSlot(islot), 43, 0x2000); //0xffff sets all channels to same threshold
-         }
-        else faSetThreshold(faSlot(islot), 1, 0xffff); //0xffff sets all channels to same threshold
-    }
-       /* Set input DAC level */ //turn off adjusting DAC for slot 2 
-     /// adding islot 0,1,2 
+     if(WANT_THRESHOLD)
+       {
+       if(islot==0)      faSetThreshold(faSlot(islot), 300+25 , 0xffff);	//GC,SO,Ref
+       else if(islot==1) faSetThreshold(faSlot(islot), 300+25 , 0xffff);	//S2
+       else if(islot==2) faSetThreshold(faSlot(islot), 300+25 , 0xffff);	//S2
+       else              faSetThreshold(faSlot(islot), 1, 0xffff); //raster, BPMs, PRL1, PRL2
+       }
+     else
+       {
+       faSetThreshold(faSlot(islot), 1, 0xffff); //0xffff sets all channels to same threshold
+       }
+
 if(islot==0)      {
         faSetDAC(faSlot(islot), 3072, 0x0001);   ///S0
 	faSetDAC(faSlot(islot), 3088, 0x0002);
@@ -187,7 +177,6 @@ if(islot==0)      {
 	faSetDAC(faSlot(islot), 2998, 0x8000);
 	//faSetDAC(faSlot(islot), 3200, 0xffff);  //previous default value
        }
-/// islot 1
 if(islot==1){
         faSetDAC(faSlot(islot), 3040, 0x0001); /// S2L
 	faSetDAC(faSlot(islot), 3059, 0x0002);
@@ -207,7 +196,6 @@ if(islot==1){
 	faSetDAC(faSlot(islot), 3046, 0x8000);
 	//faSetDAC(faSlot(islot), 3200, 0xffff);  //previous default value
        }
-// islot2 
 if(islot==2){
         faSetDAC(faSlot(islot), 3030, 0x0001); // S2R
 	faSetDAC(faSlot(islot), 3047, 0x0002);
@@ -272,7 +260,9 @@ if(islot==2){
 
       // faSetProcMode(faSlot(islot), 10, 85, 40, 5, 60, 1, 4,250,2);
        if(WANT_THRESHOLD)
-         faSetProcMode(faSlot(islot), FADC_MODE, FADC_LATENCY, FADC_WINDOW_WIDTH, 2, 13, 1, 15,400,2);
+         if(islot==3||islot==4||islot==5||islot==6||islot==7)
+             faSetProcMode(faSlot(islot), FADC_MODE, FADC_LA_Sh, FADC_WD_Sh, FADC_NSB, FADC_NSA, 1, 15,800,1);
+         else faSetProcMode(faSlot(islot), FADC_MODE, FADC_LATENCY, FADC_WINDOW_WIDTH, 2, 15, 1, 15,400,4);
        else{
          if(islot==3||islot==4||islot==5||islot==6||islot==7)
              faSetProcMode(faSlot(islot), FADC_MODE, FADC_LA_Sh, FADC_WD_Sh, FADC_NSB, FADC_NSA, 1, 15,800,1);


### PR DESCRIPTION
-remove outdated channel-by-channel threshold settings
-if TFlag, set threshold to 300+25 (=pedestal+25) for islot 0,1,2
-otherwise, threshold = 1 (i.e. threshold off)
-islot 3,4,5,6,7 never have threshold on
-if TFlag, set NSAT=4 for islot 0,1,2, and set NSA=15 and NSB=2